### PR TITLE
Fixed some bugs in evaluation codes

### DIFF
--- a/src/lib/eval/hico_eval.py
+++ b/src/lib/eval/hico_eval.py
@@ -53,6 +53,8 @@ class hico():
         self.num_class = len(self.verb_name_dict)
     def evalution(self, predict_annot):
         for pred_i in predict_annot:
+            if pred_i['file_name'] not in self.file_name:
+                continue
             gt_i = self.annotations[self.file_name.index(pred_i['file_name'])]
             gt_bbox = gt_i['annotations']
             if len(gt_bbox)!=0:
@@ -142,7 +144,11 @@ class hico():
                             if min_ov_gt>max_ov:
                                 max_ov=min_ov_gt
                                 max_gt_id=gt_id
+                if pred_hoi_i['category_id'] not in list(self.fp.keys()):
+                    continue
                 triplet = [pred_bbox[pred_hoi_i['subject_id']]['category_id'], pred_bbox[pred_hoi_i['object_id']]['category_id'], pred_hoi_i['category_id']]
+                if triplet not in self.verb_name_dict:
+                    continue
                 verb_id = self.verb_name_dict.index(triplet)
                 if is_match == 1 and vis_tag[max_gt_id] == 0:
                     self.fp[verb_id].append(0)


### PR DESCRIPTION
Hi
  I have sent you an email. Please check it.
  Details as follows:
(1)When a prediction bbox matches multiple gt bboxes, matching rules are inconsistent with official codes
(2)GT bbox cordinates are zero-based while prediction bbox are one-based
(3)The method of calculating the rectangular area is inconsistent with the official code
(4)For the images without hoi interaction, the original code skipped directly
Now the results are same as the resuls of official matlab script.

For specific bug information, you can refer to my email. (my email tjuliwenxu@tju.edu.cn)